### PR TITLE
Support unicode characters for id and class selectors

### DIFF
--- a/lib/HTML/Selector/XPath.pm
+++ b/lib/HTML/Selector/XPath.pm
@@ -20,7 +20,7 @@ my $ident = qr/(?![0-9]|-[-0-9])[-_a-zA-Z0-9]+/;
 
 my $reg = {
     # tag name/id/class
-    element => qr/^([#.]?)([a-z0-9\\*_-]*)((\|)([a-z0-9\\*_-]*))?/i,
+    element => qr/^([#.]?)([^\s'"#.\/:@,=~>()\[\]|]*)((\|)([a-z0-9\\*_-]*))?/i,
     # attribute presence
     attr1   => qr/^\[ \s* ($ident) \s* \]/x,
     # attribute value match

--- a/t/02_html.t
+++ b/t/02_html.t
@@ -418,3 +418,14 @@ div em:nth-last-child(2n+1)
 <em>here</em>
 <em>everywhere</em>
 <em>nowhere</em>
+===
+--- input
+<body>
+<div class="小飼弾">小飼弾</div>
+<div class="bar">foo</div>
+</body>
+--- selector
+div.小飼弾
+--- expected
+<div class="小飼弾">小飼弾</div>
+


### PR DESCRIPTION
`qr/^([#.]?)([a-z0-9\\*_-]*)((\|)([a-z0-9\\*_-]*))?/i` doesn't match unicode characters like `.小飼弾`.
I changed it to `qr/^([#.]?)([^\s'"#.\/:@,=~>()\[\]|]*)((\|)([a-z0-9\\*_-]*))?/i`.
